### PR TITLE
fix: don't run README generator in test matrix

### DIFF
--- a/.github/workflows/on-push-to-main-branch.yml
+++ b/.github/workflows/on-push-to-main-branch.yml
@@ -28,16 +28,6 @@ jobs:
       TEST_CACHE_NAME: python-integration-test-${{ matrix.python-version }}-${{ matrix.new-python-protobuf }}-${{ github.sha }}
     steps:
       - uses: actions/checkout@v3
-        name: Setup repo
-        with:
-          token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
-
-      - name: Generate README
-        uses: momentohq/standards-and-practices/github-actions/generate-and-commit-oss-readme@gh-actions-v1
-        with:
-          project_status: official
-          project_stability: alpha
-          project_type: other
 
       - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -76,9 +66,26 @@ jobs:
       - name: Run tests
         run: poetry run pytest -p no:sugar -q
 
+  readme:
+    runs-on: ubuntu-latest
+    needs: [test]
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Setup repo
+        with:
+          token: ${{ secrets.MOMENTO_MACHINE_USER_GITHUB_TOKEN }}
+
+      - name: Generate README
+        uses: momentohq/standards-and-practices/github-actions/generate-and-commit-oss-readme@gh-actions-v1
+        with:
+          project_status: official
+          project_stability: alpha
+          project_type: other
+
   publish:
     runs-on: ubuntu-20.04
-    needs: [test]
+    needs: [readme]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Prior to this commit, the README generator was being run
inside of the test step, which gets run on several different
versions of python. Running the README generator more than
once causes issues because the upstream branch ends up with
divergent commits in it.

This commit pulls the README generator out to be its own
job in the workflow.
